### PR TITLE
Expose rtc maths globally

### DIFF
--- a/src/viewer/scene/math/index.js
+++ b/src/viewer/scene/math/index.js
@@ -1,2 +1,3 @@
 export * from "./math.js";
-export * from "./Frustum";
+export * from "./Frustum.js";
+export * from "./rtcCoords.js";


### PR DESCRIPTION
Rtc coordinates math module is not globally exposed.
Use case:

I use the global import to expose xeokit API to end users:
```js
import * as xeokitSdk from "@xeokit/xeokit-sdk";
```
But as rtcCoords is not exposed, it is not possible to use it to handle geometries that needs rtc computations.